### PR TITLE
Switch to .env config and add HTTP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DISCORD_TOKEN=
+BOT_INVITE_URL=
+CADASTRE-SE_ID=1369758167046553774
+CADASTRE-SE_WEBHOOK=https://n8n.dinastia.uk/webhook/v1/systempoints/cadastro
+PORT=9090

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+config.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# systemPointsDiscord
+# Sistema de Pontos Discord Bot
+
+Este repositório contém um bot simples do Discord que envia uma mensagem de cadastro com um botão. Ao clicar, o usuário fornece e-mail e WhatsApp em um formulário integrado, que é enviado para o n8n através de um webhook.
+
+## Configuração
+
+1. Copie `.env.example` para `.env` e preencha as variáveis `DISCORD_TOKEN`, `CADASTRE-SE_ID`, `CADASTRE-SE_WEBHOOK` e outras se necessário.
+2. Instale as dependências com `npm install` (requer acesso à internet).
+3. Execute `npm start` para iniciar o bot. O servidor HTTP será iniciado na porta definida em `PORT` (padrão `9090`).
+
+O bot envia a mensagem no canal definido em `CADASTRE-SE_ID` quando inicia. Ao clicar em **Cadastre-se**, o usuário fornece os dados de contato que são enviados para o webhook configurado em `CADASTRE-SE_WEBHOOK`.
+Se `BOT_INVITE_URL` estiver definido, a página inicial do servidor exibe um link para convidar o bot.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,118 @@
+import 'dotenv/config';
+import express from 'express';
+import {
+  Client,
+  GatewayIntentBits,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  InteractionType,
+} from 'discord.js';
+
+const {
+  DISCORD_TOKEN,
+  CADASTRE_SE_ID,
+  CADASTRE_SE_WEBHOOK,
+  BOT_INVITE_URL,
+  PORT = 9090,
+} = process.env;
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.once('ready', async () => {
+  console.log(`Logged in as ${client.user.tag}`);
+  try {
+    const channel = await client.channels.fetch(CADASTRE_SE_ID);
+    if (!channel) {
+      console.error('Channel not found');
+      return;
+    }
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId('register')
+        .setLabel('Cadastre-se')
+        .setStyle(ButtonStyle.Primary)
+    );
+
+    const description = `\u{1F680} Cadastre-se no Sistema de Pontos da Dinastia!
+Ao clicar no bot\u00E3o abaixo, voc\u00EA ir\u00E1 preencher um formul\u00E1rio de cadastro do sistema de pontos.
+
+Esse sistema \u00E9 uma forma de recompensar voc\u00EA por sua participa\u00E7\u00E3o ativa na comunidade Dinastia.
+
+Ao longo do tempo, voc\u00EA poder\u00E1 acumular pontos e troc\u00E1-los por pr\u00EAmios incr\u00EDveis!
+
+Aproveite essa oportunidade e fa\u00E7a parte do nosso sistema de pontos!
+
+DinastIA - Bem-vindo ao Sistema de Pontos!`;
+
+    await channel.send({ content: description, components: [row] });
+    console.log('Message sent.');
+  } catch (err) {
+    console.error('Failed to send message:', err);
+  }
+});
+
+client.on('interactionCreate', async (interaction) => {
+  if (interaction.isButton() && interaction.customId === 'register') {
+    const modal = new ModalBuilder()
+      .setCustomId('registerModal')
+      .setTitle('Cadastro Sistema de Pontos');
+
+    const emailInput = new TextInputBuilder()
+      .setCustomId('email')
+      .setLabel('E-mail')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    const whatsappInput = new TextInputBuilder()
+      .setCustomId('whatsapp')
+      .setLabel('WhatsApp')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(emailInput),
+      new ActionRowBuilder().addComponents(whatsappInput),
+    );
+
+    await interaction.showModal(modal);
+  } else if (
+    interaction.type === InteractionType.ModalSubmit &&
+    interaction.customId === 'registerModal'
+  ) {
+    const email = interaction.fields.getTextInputValue('email');
+    const whatsapp = interaction.fields.getTextInputValue('whatsapp');
+
+    try {
+      await fetch(CADASTRE_SE_WEBHOOK, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          whatsapp,
+          userName: interaction.user.username,
+          discordId: interaction.user.id,
+        }),
+      });
+      await interaction.reply({ content: 'Cadastro enviado com sucesso!', ephemeral: true });
+    } catch (err) {
+      console.error('Failed to submit form:', err);
+      await interaction.reply({ content: 'Erro ao enviar cadastro.', ephemeral: true });
+    }
+  }
+});
+
+client.login(DISCORD_TOKEN);
+
+const app = express();
+app.get('/', (_req, res) => {
+  if (BOT_INVITE_URL) {
+    res.send(`<a href="${BOT_INVITE_URL}">Invite the bot</a>`);
+  } else {
+    res.send('Bot is running');
+  }
+});
+app.listen(PORT, () => console.log(`HTTP server running on port ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "system-points-discord",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "discord.js": "^14.17.1",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- ignore `.env` files
- load configuration from `.env`
- add `.env.example` sample file
- add a small Express HTTP server on configurable port
- document new environment variables in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842eb13c8ec8331a50a98ea7e5b6712